### PR TITLE
feat: Add resource cleanup controls for test factories 🧹

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,42 @@ test('it creates a user', async ({ company, createUser }) => {
 Factories ensure resources are destroyed properly after use. This avoids any residual data that might affect subsequent tests. Each factory can optionally specify a `destroy` function to clean up resources.
 Since `destroy` is called in the reverse order of fixture definition, this should avoid any dependency conflicts (e.g. mandatory foreign key relationships in database tables).
 
+### Resource Cleanup Control
+
+There are two ways to control whether resources are automatically cleaned up after tests:
+
+#### Environment Variable
+
+You can set the `TFF_SKIP_DESTROY` environment variable to any non-empty value to globally disable resource cleanup:
+
+```bash
+TFF_SKIP_DESTROY=1 npm test
+```
+
+This is useful during development when you want to inspect the state of resources after tests run.
+
+#### Per-Factory Options
+
+You can also control cleanup behavior at the factory level using the `shouldDestroy` option:
+
+```typescript
+// Disable cleanup for a specific useValueFn call
+const test = anyTest.extend({
+  company: useCompany({}, { shouldDestroy: false }),
+  createCompany: useCreateCompany({ shouldDestroy: false })
+});
+```
+
+The `shouldDestroy` option:
+- Defaults to `true` unless `TFF_SKIP_DESTROY` is set
+- Can be passed to both `useValueFn` and `useCreateFn`
+- Takes precedence over the `TFF_SKIP_DESTROY` environment variable
+
+This granular control is useful when:
+- You need to keep certain resources for inspection after specific tests
+- You want to manage cleanup manually
+- You're debugging specific test scenarios
+
 ## API
 
 ### `defineFactory(factoryFn)`

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "type": "module",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@types/node": "22.10.2",
     "tsup": "8.3.5",
     "typescript": "5.7.2",
     "vitest": "2.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-fixture-factory",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A minimal library for creating and managing test fixtures using Vitest, enabling structured, repeatable, and efficient testing processes.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@types/node':
+        specifier: 22.10.2
+        version: 22.10.2
       tsup:
         specifier: 8.3.5
         version: 8.3.5(postcss@8.4.49)(typescript@5.7.2)
@@ -19,7 +22,7 @@ importers:
         version: 5.7.2
       vitest:
         specifier: 2.1.8
-        version: 2.1.8(@types/node@22.10.1)
+        version: 2.1.8(@types/node@22.10.2)
 
 packages:
 
@@ -477,8 +480,8 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
-  '@types/node@22.10.1':
-    resolution: {integrity: sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==}
+  '@types/node@22.10.2':
+    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
 
   '@vitest/expect@2.1.8':
     resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
@@ -1234,10 +1237,9 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
-  '@types/node@22.10.1':
+  '@types/node@22.10.2':
     dependencies:
       undici-types: 6.20.0
-    optional: true
 
   '@vitest/expect@2.1.8':
     dependencies:
@@ -1246,13 +1248,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.1))':
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.2))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.14
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.1)
+      vite: 5.4.11(@types/node@22.10.2)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -1647,16 +1649,15 @@ snapshots:
 
   typescript@5.7.2: {}
 
-  undici-types@6.20.0:
-    optional: true
+  undici-types@6.20.0: {}
 
-  vite-node@2.1.8(@types/node@22.10.1):
+  vite-node@2.1.8(@types/node@22.10.2):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.1)
+      vite: 5.4.11(@types/node@22.10.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1668,19 +1669,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11(@types/node@22.10.1):
+  vite@5.4.11(@types/node@22.10.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.27.4
     optionalDependencies:
-      '@types/node': 22.10.1
+      '@types/node': 22.10.2
       fsevents: 2.3.3
 
-  vitest@2.1.8(@types/node@22.10.1):
+  vitest@2.1.8(@types/node@22.10.2):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -1696,11 +1697,11 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.10.1)
-      vite-node: 2.1.8(@types/node@22.10.1)
+      vite: 5.4.11(@types/node@22.10.2)
+      vite-node: 2.1.8(@types/node@22.10.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.10.1
+      '@types/node': 22.10.2
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/src/env-var.ts
+++ b/src/env-var.ts
@@ -1,0 +1,11 @@
+const getSkipDestroyEnvVar = (): boolean => {
+  // if we are in a node environment, check the process.env object
+  if (typeof process !== 'undefined' && 'env' in process) {
+    return (process.env.TFF_SKIP_DESTROY ?? '').trim().length > 0
+  }
+  return false
+}
+
+const SKIP_DESTROY = getSkipDestroyEnvVar()
+
+export { SKIP_DESTROY }

--- a/src/env-var.ts
+++ b/src/env-var.ts
@@ -1,7 +1,11 @@
+import { yn } from './yn.js'
+
 const getSkipDestroyEnvVar = (): boolean => {
   // if we are in a node environment, check the process.env object
   if (typeof process !== 'undefined' && 'env' in process) {
-    return (process.env.TFF_SKIP_DESTROY ?? '').trim().length > 0
+    // will return false if TFF_SKIP_DESTROY is not set
+    // or if it is set to an empty/blank string or "0"
+    return yn(process.env.TFF_SKIP_DESTROY)
   }
   return false
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,11 +15,29 @@ type FactoryInputFn<Deps, Attrs, Value> = (
   attrs: Attrs,
 ) => Promise<FactoryOutput<Value>> | FactoryOutput<Value>
 
+type FactoryOptions = {
+  // if true, the factory will destroy the created values after the test
+  // defaults to true, unless TFF_SKIP_DESTROY env var is set
+  shouldDestroy?: boolean
+}
+
 type CreateFn<Attrs, Value> = (attrs: Attrs) => Promise<Value>
 
 type Factory<Deps, Attrs, Value> = FactoryInputFn<Deps, Attrs, Value> & {
-  useCreateFn: () => VitestFixtureFn<Deps, CreateFn<Attrs, Value>>
-  useValueFn: (attrs: Attrs) => VitestFixtureFn<Deps, Value>
+  useCreateFn: (
+    options?: FactoryOptions,
+  ) => VitestFixtureFn<Deps, CreateFn<Attrs, Value>>
+  useValueFn: (
+    attrs: Attrs,
+    options?: FactoryOptions,
+  ) => VitestFixtureFn<Deps, Value>
 }
 
-export type { VitestFixtureFn, FactoryInputFn, Factory, DestroyFn, CreateFn }
+export type {
+  VitestFixtureFn,
+  FactoryInputFn,
+  Factory,
+  DestroyFn,
+  CreateFn,
+  FactoryOptions,
+}

--- a/src/yn.ts
+++ b/src/yn.ts
@@ -1,0 +1,75 @@
+/*
+ * ----------------------------------------------------------------------------
+ *
+ *  This is a fork of the `yn` package, which is a simple utility to parse a
+ *  yes/no like string into a boolean.
+ *
+ *  See https://github.com/sindresorhus/yn for the original package.
+ *
+ *  Usage:
+ *
+ *    import { yn } from './yn.ts'
+ *
+ *    // returns true
+ *    yn('y')
+ *    yn('yes')
+ *    yn('true')
+ *    yn('1')
+ *
+ *    // returns false
+ *    yn('n')
+ *    yn('no')
+ *    yn('false')
+ *    yn('0')
+ *
+ *    // unknown values return false
+ *    yn('foo')
+ *    yn('bar')
+ *    yn('baz')
+ *
+ * ----------------------------------------------------------------------------
+ *
+ *  MIT License
+ *
+ *  Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ * ----------------------------------------------------------------------------
+ */
+
+const yn = (input: unknown): boolean => {
+  if (input === undefined || input === null) {
+    return false
+  }
+
+  const value = String(input).trim()
+
+  if (/^(?:y|yes|true|1|on)$/i.test(value)) {
+    return true
+  }
+
+  if (/^(?:n|no|false|0|off)$/i.test(value)) {
+    return false
+  }
+
+  return false
+}
+
+export { yn }


### PR DESCRIPTION
This PR introduces two ways to control test resource cleanup: a global `TFF_SKIP_DESTROY` environment variable and a per-factory `shouldDestroy` option. Added comprehensive documentation with examples in README.md and implemented the necessary logic to support these features.
