### PR TITLE
feat: add default values support to field builder 🧹

### DIFF
--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -29,7 +29,7 @@ const bookFactory = defineFactory(
     authorId: f
       .type<number>()
       .useContext(({ author }: { author?: Pick<Author, 'id'> }) => author?.id),
-    title: f.type<string>().optional(),
+    title: f.type<string>().default('Unknown'),
   },
   async ({ authorId, title }) => {
     const value: Book = {

--- a/src/field-builder.test.ts
+++ b/src/field-builder.test.ts
@@ -1,51 +1,54 @@
 import { describe, expectTypeOf, test } from 'vitest'
 import { type FieldBuilder, f } from './field-builder.js'
-import type { Field } from './types.js'
+import type { Field, RequiredFlag } from './types.js'
 
-const inspect = <Context extends object, Value, IsOptional extends boolean>(
-  fieldBuilder: FieldBuilder<Context, Value, IsOptional>,
-): Field<Context, Value, IsOptional> => {
-  const field = fieldBuilder as unknown as Field<Context, Value, IsOptional>
+const inspect = <Context extends object, Value, Flag extends RequiredFlag>(
+  fieldBuilder: FieldBuilder<Context, Value, Flag>,
+): Field<Context, Value, Flag> => {
+  const field = fieldBuilder as unknown as Field<Context, Value, Flag>
   return {
     context: field.context,
-    isOptional: field.isOptional,
+    isRequired: field.isRequired,
+    defaultValue: field.defaultValue,
   }
 }
 
 describe('f', () => {
-  test('build a required attribute', ({ expect }) => {
+  test('.type()', ({ expect }) => {
     const field = f.type<string>()
 
     expectTypeOf<typeof field>().toEqualTypeOf<
-      FieldBuilder<object, string, false>
+      FieldBuilder<object, string, 'required'>
     >()
 
     expect(inspect(field)).toStrictEqual({
       context: undefined,
-      isOptional: false,
+      isRequired: true,
+      defaultValue: undefined,
     })
   })
 
-  test('build an optional attribute', ({ expect }) => {
+  test('.type().optional()', ({ expect }) => {
     const field = f.type<number>().optional()
 
     expectTypeOf<typeof field>().toEqualTypeOf<
-      FieldBuilder<object, number, true>
+      FieldBuilder<object, number | undefined, 'optional'>
     >()
 
     expect(inspect(field)).toStrictEqual({
       context: undefined,
-      isOptional: true,
+      isRequired: false,
+      defaultValue: undefined,
     })
   })
 
-  test('build a required dependency', ({ expect }) => {
+  test('.type().useContext()', ({ expect }) => {
     const field = f
       .type<boolean>()
       .useContext(({ dependency }: { dependency: boolean }) => dependency)
 
     expectTypeOf<typeof field>().toEqualTypeOf<
-      FieldBuilder<{ dependency: boolean }, boolean, false>
+      FieldBuilder<{ dependency: boolean }, boolean, 'required'>
     >()
 
     expect(inspect(field)).toStrictEqual({
@@ -53,12 +56,13 @@ describe('f', () => {
         fixtureList: ['dependency'],
         getValue: expect.any(Function),
       },
-      isOptional: false,
+      isRequired: true,
+      defaultValue: undefined,
     })
     expect(inspect(field).context?.getValue({ dependency: true })).toBe(true)
   })
 
-  test('build an optional dependency', ({ expect }) => {
+  test('.type().useContext().optional()', ({ expect }) => {
     const field = f
       .type<bigint>()
       .optional()
@@ -71,7 +75,7 @@ describe('f', () => {
       })
 
     expectTypeOf<typeof field>().toEqualTypeOf<
-      FieldBuilder<{ value?: string }, bigint, true>
+      FieldBuilder<{ value?: string }, bigint | undefined, 'optional'>
     >()
 
     expect(inspect(field)).toStrictEqual({
@@ -79,7 +83,89 @@ describe('f', () => {
         fixtureList: ['value'],
         getValue: expect.any(Function),
       },
-      isOptional: true,
+      isRequired: false,
+      defaultValue: undefined,
+    })
+    expect(inspect(field).context?.getValue?.({ value: '1234' })).toBe(1234n)
+    expect(inspect(field).context?.getValue?.({ value: 'fail' })).toBe(
+      undefined,
+    )
+  })
+
+  test('.type().default()', ({ expect }) => {
+    const field = f.type<string>().default('default')
+
+    expectTypeOf<typeof field>().toEqualTypeOf<
+      FieldBuilder<object, string, 'optional'>
+    >()
+
+    expect(inspect(field)).toStrictEqual({
+      context: undefined,
+      isRequired: false,
+      defaultValue: 'default',
+    })
+  })
+
+  test('.type().default().optional()', ({ expect }) => {
+    const field = f.type<number>().default(123).optional()
+
+    expectTypeOf<typeof field>().toEqualTypeOf<
+      FieldBuilder<object, number | undefined, 'optional'>
+    >()
+
+    expect(inspect(field)).toStrictEqual({
+      context: undefined,
+      isRequired: false,
+      defaultValue: 123,
+    })
+  })
+
+  test('.type().useContext().default()', ({ expect }) => {
+    const field = f
+      .type<boolean>()
+      .default(false)
+      .useContext(({ value }: { value?: string }) => value === 'true')
+
+    expectTypeOf<typeof field>().toEqualTypeOf<
+      FieldBuilder<{ value?: string }, boolean, 'optional'>
+    >()
+
+    expect(inspect(field)).toStrictEqual({
+      context: {
+        fixtureList: ['value'],
+        getValue: expect.any(Function),
+      },
+      isRequired: false,
+      defaultValue: false,
+    })
+    expect(inspect(field).context?.getValue?.({ value: 'true' })).toBe(true)
+    expect(inspect(field).context?.getValue?.({ value: 'fail' })).toBe(false)
+  })
+
+  test('.type().useContext().default().optional()', ({ expect }) => {
+    const field = f
+      .type<bigint>()
+      .default(123n)
+      .optional()
+      .useContext(({ value }: { value?: string }) => {
+        try {
+          return typeof value === 'string' ? BigInt(value) : undefined
+        } catch {
+          return undefined
+        }
+      })
+
+    expectTypeOf<typeof field>().toEqualTypeOf<
+      FieldBuilder<{ value?: string }, bigint | undefined, 'optional'>
+    >()
+
+    expect(inspect(field)).toStrictEqual({
+      context: {
+        fixtureList: ['value'],
+        getValue: expect.any(Function),
+      },
+      isRequired: false,
+      defaultValue: 123n,
     })
     expect(inspect(field).context?.getValue?.({ value: '1234' })).toBe(1234n)
     expect(inspect(field).context?.getValue?.({ value: 'fail' })).toBe(

--- a/src/schema-utils.test.ts
+++ b/src/schema-utils.test.ts
@@ -1,0 +1,102 @@
+import { describe, test } from 'vitest'
+import { f } from './field-builder.js'
+
+import {
+  getFixtureList,
+  resolveSchema,
+  validateSchemaData,
+} from './schema-utils.js'
+
+describe('resolveSchema', () => {
+  test('should resolve default values', ({ expect }) => {
+    const schema = {
+      a: f.type<number>().default(1),
+      b: f.type<number>().default(2),
+      c: f.type<number>().default(3),
+    }
+
+    const result = resolveSchema(schema, {}, {})
+
+    expect(result).toStrictEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    })
+  })
+
+  test('should resolve deps', ({ expect }) => {
+    const schema = {
+      a: f.type<number>().useContext(({ a }: { a: number }) => a),
+      b: f.type<number>().useContext(({ b }: { b: number }) => b),
+      c: f.type<number>().useContext(({ c }: { c: number }) => c),
+    }
+
+    const result = resolveSchema(schema, { a: 1, b: 2, c: 3 }, {})
+
+    expect(result).toStrictEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    })
+  })
+
+  test('should resolve attrs', ({ expect }) => {
+    const schema = {
+      a: f.type<number>(),
+      b: f.type<number>(),
+      c: f.type<number>(),
+    }
+
+    const result = resolveSchema(schema, {}, { a: 1, b: 2, c: 3 })
+
+    expect(result).toStrictEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    })
+  })
+})
+
+describe('validateSchemaData', () => {
+  test('should validate schema data', ({ expect }) => {
+    const schema = {
+      a: f.type<number>(),
+      b: f.type<number>(),
+      c: f.type<number>(),
+    }
+
+    const result = validateSchemaData(schema, { a: 1, b: 2, c: 3 })
+
+    expect(result).toStrictEqual([])
+  })
+
+  test('should validate schema data with missing fields', ({ expect }) => {
+    const schema = {
+      a: f.type<number>(),
+      b: f.type<number>(),
+      c: f.type<number>(),
+    }
+
+    const result = validateSchemaData(schema, {
+      a: 1,
+      b: 2,
+      c: undefined as unknown as number,
+    })
+
+    expect(result).toStrictEqual([['c', schema.c]])
+  })
+})
+
+describe('getFixtureList', () => {
+  test('should get fixture list', ({ expect }) => {
+    const schema = {
+      a: f.type<number>().useContext(({ a }: { a: number }) => a),
+      b: f.type<number>().useContext(({ b }: { b: number }) => b),
+      c: f.type<number>().useContext(({ c }: { c: number }) => c),
+    }
+
+    const result = getFixtureList(schema)
+
+    expect(result).toStrictEqual(['a', 'b', 'c'])
+  })
+})

--- a/src/schema-utils.ts
+++ b/src/schema-utils.ts
@@ -18,6 +18,14 @@ const schemaValues = <S extends AnySchema>(s: S): Array<AnyField> => {
   return Object.values(s as unknown as AnyReadableSchema)
 }
 
+const resolveDefaultValues = <S extends AnySchema>(schema: S) => {
+  return Object.fromEntries(
+    schemaEntries(schema).map(([key, value]) => {
+      return [key, value.defaultValue]
+    }),
+  )
+}
+
 const resolveDeps = <S extends AnySchema>(schema: S, deps: DepsOf<S>) => {
   return Object.fromEntries(
     schemaEntries(schema)
@@ -36,7 +44,7 @@ const validateSchemaData = <S extends AnySchema>(
 ): [string, AnyField][] => {
   return schemaEntries(schema).filter(([key, field]) => {
     // ignore optional fields
-    if (field.isOptional) {
+    if (!field.isRequired) {
       return false
     }
     // ignore fields that are already defined
@@ -53,6 +61,7 @@ const resolveSchema = <S extends AnySchema>(
   attrs: Voidable<InputAttrsOf<S>>,
 ) => {
   const result = {
+    ...resolveDefaultValues(schema),
     ...resolveDeps(schema, deps),
     ...attrs,
   } as AttrsOf<S>


### PR DESCRIPTION
This commit enhances the field builder by introducing default values functionality for fields. This allows for the automatic assignment of specified default values when fields are not provided by users, streamlining data handling and improving user experience.

- Modified `example.test.ts` to use default title value of 'Unknown'.
- Updated `field-builder.test.ts` to validate default values in multiple test scenarios, including `default()` and `default().optional()`.
- Altered the `field-builder.ts` class to store `defaultValue` and updated other related logic to reflect this change.
- Created `schema-utils.test.ts` to test the new default value resolution in the schema.
- Adjusted `schema-utils.ts` to incorporate resolving default values when assembling schema data.
- Enhanced `types.ts` to differentiate field requirements using a `RequiredFlag`.

These changes provide a more robust field definition capability, helping to ensure that defaults are set when data is incomplete, improving overall application reliability.