### PR TITLE
fix: improve type definitions and test fixtures 📦

### DIFF
--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -29,12 +29,13 @@ const bookFactory = defineFactory(
     authorId: f
       .type<number>()
       .useContext(({ author }: { author?: Pick<Author, 'id'> }) => author?.id),
+    id: f.type<number>().default(Math.floor(Math.random() * 1_000_000)),
     title: f.type<string>().default('Unknown'),
   },
-  async ({ authorId, title }) => {
+  async ({ id, authorId, title }) => {
     const value: Book = {
-      id: Math.floor(Math.random() * 1_000_000),
-      title: title ?? 'Unknown',
+      id,
+      title: title,
       authorId,
     }
     return { value }


### PR DESCRIPTION
This commit refines the type definitions in `types.ts` and improves the `example.test.ts` file by modifying how IDs are handled in test fixtures. The goal behind these changes is to enhance type safety and clarify the usage of context within the fixture functions.

- Added an `id` field to the `example.test.ts` fixture that defaults to a random number, ensuring that books always have unique IDs provided.
- Updated various type parameters in `types.ts` to use `Context` instead of `Deps`, improving clarity and consistency in naming conventions.
- Adjusted the type definitions for fixture functions and their dependencies in `types.ts` to match the new context-based approach, enhancing type inference for fixtures.