### PR TITLE
fix: increment package version to 2.0.0-3 🧹

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-fixture-factory",
-  "version": "2.0.0-2",
+  "version": "2.0.0-3",
   "packageManager": "pnpm@10.15.0",
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
Updated the package version in `package.json` from 2.0.0-2 to 2.0.0-3. This change is necessary to signify a new version release and ensure compatibility with updates.

- Changed version number from 2.0.0-2 to 2.0.0-3 in `package.json` to reflect the latest updates.