### PR TITLE
fix: bump version to 2.0.0-4 🧹

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-fixture-factory",
-  "version": "2.0.0-3",
+  "version": "2.0.0-4",
   "packageManager": "pnpm@10.15.0",
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
This commit updates the version number in `package.json` to reflect the latest changes and prepares for the next release. It's important to keep the versioning in check for proper package management and to signal updates to users.

- Updated version from 2.0.0-3 to 2.0.0-4 in `package.json`.