### PR TITLE
feat: update default values management in schema factories 🧹

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-fixture-factory",
-  "version": "2.0.0-4",
+  "version": "2.0.0-5",
   "packageManager": "pnpm@10.15.0",
   "engines": {
     "node": ">=24.0.0"

--- a/src/create-factory.test.ts
+++ b/src/create-factory.test.ts
@@ -15,15 +15,12 @@ const getFactory = () => {
     .withSchema((f) => ({
       name: f
         .type<string>()
-        .default('Unknown')
         .dependsOn('name')
-        .use(({ name }) => name),
-
+        .default(({ name }) => name ?? 'Unknown'),
       accountId: f
         .type<number>()
-        .default(-1)
         .dependsOn('accountId')
-        .use(({ accountId }) => accountId),
+        .default(({ accountId }) => accountId ?? -1),
     }))
     .withFn((attrs) => {
       const { name, accountId } = attrs
@@ -245,13 +242,14 @@ describe('vitest.extend', () => {
 
   const accountFactory = createFactory('Account')
     .withSchema((f) => ({
-      name: f.type<string>().optional(),
+      id: f.type<number>().default(() => Math.floor(Math.random() * 10000000)),
+      name: f.type<string>().default('Test Account'),
     }))
-    .withFn(async ({ name }) => {
+    .withFn(async ({ id, name }) => {
       return {
         value: {
-          id: Math.floor(Math.random() * 10000000),
-          name: name ?? 'Test Account',
+          id,
+          name,
         },
       }
     })
@@ -265,11 +263,11 @@ describe('vitest.extend', () => {
   const personFactory = createFactory('Person')
     .withContext<{ account?: Account }>()
     .withSchema((f) => ({
-      id: f.type<number>().default(Math.floor(Math.random() * 10000000)),
+      id: f.type<number>().default(() => Math.floor(Math.random() * 10000000)),
       accountId: f
         .type<number>()
         .dependsOn('account')
-        .use(({ account }) => account?.id),
+        .optionalDefault(({ account }) => account?.id),
       name: f.type<string>().default('Test Person'),
     }))
     .withFn(({ id, accountId, name }) => {

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -6,7 +6,7 @@ type Author = { id: number; name: string }
 
 const authorFactory = createFactory('Author')
   .withSchema((f) => ({
-    id: f.type<number>().default(Math.floor(Math.random() * 1_000_000)),
+    id: f.type<number>().default(() => Math.floor(Math.random() * 1_000_000)),
     name: f.type<string>(),
   }))
   .withFn(async (attrs) => {
@@ -30,8 +30,8 @@ const bookFactory = createFactory('Book')
     authorId: f
       .type<number>()
       .dependsOn('author')
-      .use(({ author }) => author?.id),
-    id: f.type<number>().default(Math.floor(Math.random() * 1_000_000)),
+      .optionalDefault(({ author }) => author?.id),
+    id: f.type<number>().default(() => Math.floor(Math.random() * 1_000_000)),
     title: f.type<string>().default('Unknown'),
   }))
   .withFn(async (attrs) => {

--- a/src/field.test.ts
+++ b/src/field.test.ts
@@ -30,7 +30,6 @@ describe('createFieldFactory', () => {
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: [],
-      fromContext: undefined,
       isRequired: true,
       defaultValue: undefined,
     })
@@ -46,13 +45,12 @@ describe('createFieldFactory', () => {
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: [],
-      fromContext: undefined,
       isRequired: false,
       defaultValue: undefined,
     })
   })
 
-  test('.type().use()', ({ expect }) => {
+  test('.type().default(fn)', ({ expect }) => {
     const f = createFieldBuilder<{
       dependency: boolean
     }>()
@@ -60,33 +58,27 @@ describe('createFieldFactory', () => {
     const field = f
       .type<boolean>()
       .dependsOn('dependency')
-      .use(({ dependency }) => dependency)
+      .default(({ dependency }) => dependency)
 
     expectTypeOf<typeof field>().toEqualTypeOf<
-      FieldBuilder<{ dependency: boolean }, 'dependency', boolean, 'required'>
+      FieldBuilder<{ dependency: boolean }, 'dependency', boolean, 'optional'>
     >()
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: ['dependency'],
-      fromContext: expect.any(Function),
-      isRequired: true,
-      defaultValue: undefined,
+      isRequired: false,
+      defaultValue: expect.any(Function),
     })
-    expect(inspect(field).fromContext?.({ dependency: true })).toBe(true)
   })
 
-  test('.type().use().optional()', ({ expect }) => {
+  test('.type().default(fn).optional()', ({ expect }) => {
     const f = createFieldBuilder<{ value?: string }>()
     const field = f
       .type<bigint>()
       .optional()
       .dependsOn('value')
-      .use(({ value }) => {
-        try {
-          return typeof value === 'string' ? BigInt(value) : undefined
-        } catch {
-          return undefined
-        }
+      .default(({ value }) => {
+        return typeof value === 'string' ? BigInt(value) : undefined
       })
 
     expectTypeOf<typeof field>().toEqualTypeOf<
@@ -95,12 +87,9 @@ describe('createFieldFactory', () => {
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: ['value'],
-      fromContext: expect.any(Function),
       isRequired: false,
-      defaultValue: undefined,
+      defaultValue: expect.any(Function),
     })
-    expect(inspect(field).fromContext?.({ value: '1234' })).toBe(1234n)
-    expect(inspect(field).fromContext?.({ value: 'fail' })).toBe(undefined)
   })
 
   test('.type().default()', ({ expect }) => {
@@ -113,7 +102,6 @@ describe('createFieldFactory', () => {
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: [],
-      fromContext: undefined,
       isRequired: false,
       defaultValue: 'default',
     })
@@ -129,20 +117,18 @@ describe('createFieldFactory', () => {
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: [],
-      fromContext: undefined,
       isRequired: false,
       defaultValue: 123,
     })
   })
 
-  test('.type().use().default()', ({ expect }) => {
+  test('.type().default(fn)', ({ expect }) => {
     const f = createFieldBuilder<{ value?: string }>()
 
     const field = f
       .type<boolean>()
-      .default(false)
       .dependsOn('value')
-      .use(({ value }) => value === 'true')
+      .default(({ value }) => value === 'true')
 
     expectTypeOf<typeof field>().toEqualTypeOf<
       FieldBuilder<{ value?: string }, 'value', boolean, 'optional'>
@@ -150,41 +136,29 @@ describe('createFieldFactory', () => {
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: ['value'],
-      fromContext: expect.any(Function),
       isRequired: false,
-      defaultValue: false,
+      defaultValue: expect.any(Function),
     })
-    expect(inspect(field).fromContext?.({ value: 'true' })).toBe(true)
-    expect(inspect(field).fromContext?.({ value: 'fail' })).toBe(false)
   })
 
-  test('.type().use().default().optional()', ({ expect }) => {
+  test('.type().optionalDefault(fn)', ({ expect }) => {
     const f = createFieldBuilder<{ value?: string }>()
 
     const field = f
       .type<bigint>()
-      .default(123n)
-      .optional()
       .dependsOn('value')
-      .use(({ value }) => {
-        try {
-          return typeof value === 'string' ? BigInt(value) : undefined
-        } catch {
-          return undefined
-        }
+      .optionalDefault(({ value }) => {
+        return typeof value === 'string' ? BigInt(value) : undefined
       })
 
     expectTypeOf<typeof field>().toEqualTypeOf<
-      FieldBuilder<{ value?: string }, 'value', bigint | undefined, 'optional'>
+      FieldBuilder<{ value?: string }, 'value', bigint, 'required'>
     >()
 
     expect(inspect(field)).toStrictEqual<AnyField>({
       fixtureList: ['value'],
-      fromContext: expect.any(Function),
-      isRequired: false,
-      defaultValue: 123n,
+      isRequired: true,
+      defaultValue: expect.any(Function),
     })
-    expect(inspect(field).fromContext?.({ value: '1234' })).toBe(1234n)
-    expect(inspect(field).fromContext?.({ value: 'fail' })).toBe(undefined)
   })
 })

--- a/src/schema-utils.test.ts
+++ b/src/schema-utils.test.ts
@@ -12,7 +12,7 @@ describe('resolveSchema', () => {
     const schema = createSchema().with((f) => ({
       a: f.type<number>().default(1),
       b: f.type<number>().default(2),
-      c: f.type<number>().default(3),
+      c: f.type<number>().default(() => 3),
     }))
 
     const result = resolveSchema(schema, {}, {})
@@ -30,15 +30,15 @@ describe('resolveSchema', () => {
         a: f
           .type<number>()
           .dependsOn('a')
-          .use(({ a }) => a),
+          .default(({ a }) => a),
         b: f
           .type<number>()
           .dependsOn('b')
-          .use(({ b }) => b),
+          .default(({ b }) => b),
         c: f
           .type<number>()
           .dependsOn('c')
-          .use(({ c }) => c),
+          .default(({ c }) => c),
       }),
     )
 
@@ -110,11 +110,11 @@ describe('getFixtureList', () => {
         a: f
           .type<number>()
           .dependsOn('a')
-          .use(({ a }) => a),
+          .default(({ a }) => a),
         bc: f
           .type<number>()
           .dependsOn('b', 'c')
-          .use(({ b, c }) => b + c),
+          .default(({ b, c }) => b + c),
       }),
     )
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -220,7 +220,7 @@ describe('OptionalInputKeysOf<S>', () => {
       name: f
         .type<string>()
         .dependsOn('name')
-        .use(({ name }) => name),
+        .optionalDefault(({ name }) => name),
       age: f.type<number>(),
     }))
     type Actual = OptionalInputKeysOf<typeof schema>
@@ -265,7 +265,7 @@ describe('RequiredInputKeysOf<S>', () => {
       name: f
         .type<string>()
         .dependsOn('name')
-        .use(({ name }) => name),
+        .optionalDefault(({ name }) => name),
       age: f.type<number>(),
     }))
     type Actual = RequiredInputKeysOf<typeof schema>
@@ -301,12 +301,11 @@ describe('InputOf<S>', () => {
       c: f
         .type<'c'>()
         .dependsOn('c')
-        .use(({ c }) => c),
+        .default(({ c }) => c),
       d: f
         .type<'d'>()
         .dependsOn('d')
-        .use(({ d }) => d)
-        .optional(),
+        .optionalDefault(({ d }) => d),
     }))
     type Actual = InputOf<typeof schema>
     type Expected = {
@@ -360,7 +359,7 @@ describe('VoidableInputOf<S>', () => {
       name: f
         .type<string>()
         .dependsOn('name')
-        .use(({ name }) => name),
+        .default(({ name }) => name),
     }))
     type Actual = VoidableInputOf<typeof schema>
     type Expected = { name?: string | undefined } | void

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,9 +13,8 @@ type RequiredFlag = 'required' | 'optional'
 
 type Field<Fixtures extends object, Value, Flag extends RequiredFlag> = {
   fixtureList: (keyof Fixtures & string)[]
-  fromContext: ((ctx: Fixtures) => Value | undefined) | undefined
   isRequired: Flag extends 'required' ? true : false
-  defaultValue: Value | undefined
+  defaultValue: undefined | Value | ((tcx: Fixtures) => Value | undefined)
 }
 
 // cast a FieldBuilder to a Field
@@ -63,7 +62,7 @@ type MissingField = {
 
 /* VITEST FIXTURE */
 
-type DestroyFn = () => Promise<void>
+type DestroyFn = () => Promise<void> | void
 
 type VitestFixtureFn<Context, FixtureValue> = (
   context: object & Context,

--- a/src/wrap-fixture-fn.test.ts
+++ b/src/wrap-fixture-fn.test.ts
@@ -26,7 +26,7 @@ test('should wrap a function with dependencies (arrow)', ({ expect }) => {
     value: f
       .type<string>()
       .dependsOn('name')
-      .use(({ name }) => name),
+      .default(({ name }) => name),
   }))
 
   const spy = vi.fn()
@@ -39,7 +39,7 @@ test('should wrap a function with dependencies (function)', ({ expect }) => {
     value: f
       .type<string>()
       .dependsOn('user')
-      .use(({ user }) => user.name),
+      .default(({ user }) => user.name),
   }))
   const spy = vi.fn()
   const test = wrapFixtureFn(schema, spy)
@@ -51,7 +51,7 @@ test('should use dep name from decode fn', ({ expect }) => {
     value: f
       .type<string>()
       .dependsOn('user')
-      .use(({ user }) => user.name),
+      .default(({ user }) => user.name),
   }))
   const spy = vi.fn()
   const test = wrapFixtureFn(schema, spy)
@@ -65,11 +65,11 @@ test('should wrap a function with dependencies and attributes', ({
     valueA: f
       .type<string>()
       .dependsOn('name')
-      .use(({ name }) => name),
+      .default(({ name }) => name),
     valueB: f
       .type<number>()
       .dependsOn('age')
-      .use(({ age }) => age),
+      .default(({ age }) => age),
     valueC: f.type<string>().optional(),
   }))
   const spy = vi.fn()


### PR DESCRIPTION
This commit refines how default values are assigned to fields within factories by transitioning from a `.use()` strategy to a `.default()` functionality, enhancing both clarity and functionality in how defaults are handled. 

- Changed `.use()` to `.default()` in various factory schemas for better semantics regarding default values.
- Updated the definition of `optional` behavior to accommodate new default value handling, ensuring all scenarios are efficient.
- Ensured that default values can now be functions that take context, adding flexibility to how defaults are computed based on other fields.
- Made corresponding adjustments in test cases to align with the new approach to default values and removed obsolete `.use()` calls.

These changes improve the overall design of the schema and simplify how default values are set, making it clearer to users how defaults relate to their contexts.