### PR TITLE
chore: bump version to 2.0.0-6 and enhance error messages 🔧

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-fixture-factory",
-  "version": "2.0.0-5",
+  "version": "2.0.0-6",
   "packageManager": "pnpm@10.15.0",
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
This commit updates the version number of the package and improves error handling in the `create-factory.ts` file. The goal is to provide clearer feedback to developers about the setup requirements for the factory functions.

- Updated version in `package.json` from 2.0.0-5 to 2.0.0-6 
- Enhanced error messages in `create-factory.ts` for better clarity:
  - Changed the error message for missing factory function in `build()`, `useCreateValue()`, and `useValue()` methods to specify that `.withFn()` needs to be called first.
- Modified parameters in function signatures for consistency, specifically changing `deps` to `context` which aligns with the expected input for context-based operations.