### PR TITLE
refactor: rename withFn to withValue for clarity 🛠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-fixture-factory",
-  "version": "2.0.0-6",
+  "version": "2.0.0-7",
   "packageManager": "pnpm@10.15.0",
   "engines": {
     "node": ">=24.0.0"

--- a/src/create-factory.test.ts
+++ b/src/create-factory.test.ts
@@ -22,7 +22,7 @@ const getFactory = () => {
         .dependsOn('accountId')
         .default(({ accountId }) => accountId ?? -1),
     }))
-    .withFn((attrs) => {
+    .withValue((attrs) => {
       const { name, accountId } = attrs
 
       const value = {
@@ -245,7 +245,7 @@ describe('vitest.extend', () => {
       id: f.type<number>().default(() => Math.floor(Math.random() * 10000000)),
       name: f.type<string>().default('Test Account'),
     }))
-    .withFn(async ({ id, name }) => {
+    .withValue(async ({ id, name }) => {
       return {
         value: {
           id,
@@ -270,7 +270,7 @@ describe('vitest.extend', () => {
         .optionalDefault(({ account }) => account?.id),
       name: f.type<string>().default('Test Person'),
     }))
-    .withFn(({ id, accountId, name }) => {
+    .withValue(({ id, accountId, name }) => {
       const person: Person = {
         id,
         accountId,

--- a/src/create-factory.ts
+++ b/src/create-factory.ts
@@ -7,6 +7,7 @@ import type {
   FactoryOptions,
   InputOf,
   OutputOf,
+  Prettify,
   SchemaOf,
   VitestFixtureFn,
   VoidableInputOf,
@@ -28,7 +29,7 @@ const defaultFactoryOptions: FactoryOptions = {
 type FactoryState<S extends AnySchema, V> = {
   name: string
   schema: S
-  factoryFn: FactoryFn<OutputOf<S>, V> | undefined
+  factoryFn: FactoryFn<Prettify<OutputOf<S>>, V> | undefined
 }
 
 type CreateFn<Schema extends AnySchema, Value> = (
@@ -58,7 +59,7 @@ class FactoryBuilder<Context extends object, Schema extends AnySchema, Value> {
     })
   }
 
-  withFn<Value>(factoryFn: FactoryFn<OutputOf<Schema>, Value>) {
+  withValue<Value>(factoryFn: FactoryFn<Prettify<OutputOf<Schema>>, Value>) {
     return new FactoryBuilder<Context, Schema, Value>({
       ...this.state,
       factoryFn,
@@ -69,7 +70,7 @@ class FactoryBuilder<Context extends object, Schema extends AnySchema, Value> {
     const { name, schema, factoryFn } = this.state
 
     if (!factoryFn) {
-      throw new Error('.withFn() must be called before .build()')
+      throw new Error('.withValue() must be called before .build()')
     }
 
     const data = resolveSchema(schema, context, attrs)
@@ -93,7 +94,7 @@ class FactoryBuilder<Context extends object, Schema extends AnySchema, Value> {
     const { name, schema, factoryFn } = this.state
 
     if (!factoryFn) {
-      throw new Error('.withFn() must be called before .useCreateValue()')
+      throw new Error('.withValue() must be called before .useCreateValue()')
     }
 
     return wrapFixtureFn(schema, async (context, use) => {
@@ -135,7 +136,7 @@ class FactoryBuilder<Context extends object, Schema extends AnySchema, Value> {
     const { shouldDestroy } = options
 
     if (!factoryFn) {
-      throw new Error('.withFn() must be called before .useValue()')
+      throw new Error('.withValue() must be called before .useValue()')
     }
 
     return wrapFixtureFn(schema, async (context, use) => {

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -9,7 +9,7 @@ const authorFactory = createFactory('Author')
     id: f.type<number>().default(() => Math.floor(Math.random() * 1_000_000)),
     name: f.type<string>(),
   }))
-  .withFn(async (attrs) => {
+  .withValue(async (attrs) => {
     const { id, name } = attrs
 
     const value: Author = {
@@ -34,7 +34,7 @@ const bookFactory = createFactory('Book')
     id: f.type<number>().default(() => Math.floor(Math.random() * 1_000_000)),
     title: f.type<string>().default('Unknown'),
   }))
-  .withFn(async (attrs) => {
+  .withValue(async (attrs) => {
     const { id, authorId, title } = attrs
 
     const value: Book = {


### PR DESCRIPTION
This commit renames the `withFn` method to `withValue` across multiple files to better reflect its purpose, enhancing code readability and understanding. 

- In `create-factory.test.ts`, updated the method name in test cases to `withValue`.
- In `create-factory.ts`, changed instances of `withFn` to `withValue`, including updates to error messages for consistency.
- In `example.test.ts`, modified the test cases to replace `withFn` with `withValue`.

These changes improve clarity, making it easier for developers to understand the function's role in the factory pattern.