### PR TITLE
chore: update version and enhance empty schema handling 🧹

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-fixture-factory",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packageManager": "pnpm@10.15.0",
   "engines": {
     "node": ">=24.0.0"

--- a/src/create-factory.ts
+++ b/src/create-factory.ts
@@ -3,6 +3,7 @@ import type {
   AnySchema,
   AnySchemaBuilderWithContext,
   DestroyFn,
+  EmptySchema,
   FactoryFn,
   FactoryOptions,
   InputOf,
@@ -175,7 +176,7 @@ const createFactory = (name: string) => {
     throw new Error('createFactory: name should be a non-empty string')
   }
 
-  return new FactoryBuilder<object, AnySchema, unknown>({
+  return new FactoryBuilder<object, EmptySchema, unknown>({
     name,
     schema: {},
     factoryFn: undefined,

--- a/src/schema-utils.ts
+++ b/src/schema-utils.ts
@@ -3,6 +3,7 @@ import type {
   AnySchema,
   AnySchemaBuilderWithContext,
   AnySchemaWithContext,
+  EmptySchema,
   FieldOf,
   MissingField,
   OutputOf,
@@ -14,7 +15,7 @@ import type {
 import { createFieldBuilder } from './field.js'
 
 const createSchema = <Context extends object = object>() => ({
-  empty: () => {
+  empty: (): EmptySchema => {
     return {}
   },
   with: <SchemaBuilder extends AnySchemaBuilderWithContext<Context>>(

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, test } from 'vitest'
 
 import type {
+  EmptySchema,
   FlagOf,
   InputOf,
   OptionalInputKeysOf,
@@ -38,8 +39,7 @@ describe('OutputOf<S>', () => {
   test('empty schema', () => {
     const schema = createSchema().empty()
     type Actual = OutputOf<typeof schema>
-    // biome-ignore lint/complexity/noBannedTypes: it is what it is
-    type Expected = {}
+    type Expected = EmptySchema
     expectTypeOf<Actual>().toEqualTypeOf<Expected>()
   })
 
@@ -153,6 +153,13 @@ describe('RequiredOutputKeysOf<S>', () => {
 })
 
 describe('OptionalInputKeysOf<S>', () => {
+  test('empty schema', () => {
+    const schema = createSchema().empty()
+    type Actual = OptionalInputKeysOf<typeof schema>
+    type Expected = never
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
   test('no optional keys', () => {
     const schema = createSchema().with((f) => ({
       name: f.type<string>(),
@@ -195,6 +202,13 @@ describe('OptionalInputKeysOf<S>', () => {
 })
 
 describe('RequiredInputKeysOf<S>', () => {
+  test('empty schema', () => {
+    const schema = createSchema().empty()
+    type Actual = RequiredInputKeysOf<typeof schema>
+    type Expected = never
+    expectTypeOf<Actual>().toEqualTypeOf<Expected>()
+  })
+
   test('all required keys', () => {
     const schema = createSchema().with((f) => ({
       name: f.type<string>(),
@@ -240,8 +254,7 @@ describe('InputOf<S>', () => {
   test('empty schema', () => {
     const schema = createSchema().empty()
     type Actual = InputOf<typeof schema>
-    // biome-ignore lint/complexity/noBannedTypes: it is what it is
-    type Expected = {}
+    type Expected = EmptySchema
     expectTypeOf<Actual>().toEqualTypeOf<Expected>()
   })
 
@@ -287,8 +300,7 @@ describe('VoidableInputOf<S>', () => {
   test('no fields', () => {
     const schema = createSchema().empty()
     type Actual = VoidableInputOf<typeof schema>
-    // biome-ignore lint/complexity/noBannedTypes: it is what it is
-    type Expected = {} | void
+    type Expected = void | EmptySchema
     expectTypeOf<Actual>().toEqualTypeOf<Expected>()
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ type AnyFieldWithContext<Context extends object> = Field<Context, any, any>
 type FieldOf<Schema extends AnySchema> = Schema[keyof Schema]
 
 type AnySchema = Record<string, AnyFieldWithContext<any>>
+type EmptySchema = Record<string, never>
 
 type AnySchemaWithContext<Context extends object> = Record<
   string,
@@ -147,22 +148,25 @@ type OptionalInputKeysOf<S extends AnySchema> = {
 }[keyof S]
 
 // keys that are required in INPUT (not optional and no dep)
-type RequiredInputKeysOf<S extends AnySchema> = Exclude<
-  keyof S,
-  OptionalInputKeysOf<S>
->
+type RequiredInputKeysOf<S extends AnySchema> = S extends EmptySchema
+  ? never
+  : Exclude<keyof S, OptionalInputKeysOf<S>>
 
 // type attrs to be provided by the test
 // any attrs that are marked as 'optional' will be optional
 // any attrs that may be resolved from context are also optional
-type InputOf<S extends AnySchema> = Prettify<
-  { [K in RequiredInputKeysOf<S>]: ValueOf<S, K> } & {
-    [K in OptionalInputKeysOf<S>]?: ValueOf<S, K>
-  }
->
+type InputOf<S extends AnySchema> = S extends EmptySchema
+  ? EmptySchema
+  : Prettify<
+      { [K in RequiredInputKeysOf<S>]: ValueOf<S, K> } & {
+        [K in OptionalInputKeysOf<S>]?: ValueOf<S, K>
+      }
+    >
 
 // type of attrs that will be provided to the factory fn
-type OutputOf<S extends AnySchema> = { [K in keyof S]: ValueOf<S, K> }
+type OutputOf<S extends AnySchema> = S extends EmptySchema
+  ? EmptySchema
+  : { [K in keyof S]: ValueOf<S, K> }
 
 type VoidableInputOf<Schema extends AnySchema> =
   RequiredInputKeysOf<Schema> extends never
@@ -205,6 +209,7 @@ export type {
   AnySchemaBuilderWithContext,
   AnySchemaWithContext,
   DestroyFn,
+  EmptySchema,
   FactoryFn,
   FactoryOptions,
   Field,


### PR DESCRIPTION
In this commit, I updated the package version and improved the handling of the `EmptySchema` type across multiple files. This change ensures better type safety and consistency in our schema utilities.

- Updated package version from 2.0.1 to 2.0.2 in `package.json`.
- Introduced `EmptySchema` type in `types.ts` to represent an empty schema more accurately.
- Refactored the `createFactory` function in `create-factory.ts` to use the new `EmptySchema`.
- Modified return types in `schema-utils.ts`, and the types in `types.test.ts` have been updated to reflect the usage of `EmptySchema`.
- Enhanced type definitions for `InputOf` and `OutputOf` to return `EmptySchema` when the schema is empty, improving clarity and reducing unnecessary complexity.

These changes are aimed at making the type system more robust and intuitive when dealing with empty schemas.